### PR TITLE
docs: polish README, add env example and contributing guide

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,23 @@
+# Example environment variables for Photo2Profit (frontend + functions)
+
+# Firebase
+FIREBASE_API_KEY=
+FIREBASE_AUTH_DOMAIN=
+FIREBASE_PROJECT_ID=
+FIREBASE_STORAGE_BUCKET=
+FIREBASE_MESSAGING_SENDER_ID=
+FIREBASE_APP_ID=
+
+# Stripe (optional)
+STRIPE_SECRET_KEY=
+STRIPE_PRICE_ID=
+
+# APIs (optional)
+REMOVEBG_API_KEY=
+EBAY_APP_ID=
+EBAY_CERT_ID=
+EBAY_DEV_ID=
+EBAY_OAUTH_TOKEN=
+
+# SendGrid (for weekly emails in Cloud Functions)
+SENDGRID_API_KEY=

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,34 @@
+# Contributing to Photo2Profit
+
+Thanks for your interest in contributing! This project uses a few simple quality gates and conventions to keep changes smooth and safe.
+
+## Development
+
+- Install dependencies: `npm install`
+- Start dev server: `npm run dev`
+- Run all local checks: `npm run lint && npm run format:check && npm test && npm run build`
+
+## Pull Requests
+
+- Branch from `main`
+- Ensure CI passes (lint, format:check, tests, build)
+- Prefer small, focused changes with a clear summary
+- Do not commit secrets; use `.env` locally (see `.env.example`)
+
+## Automated agents
+
+If you are using a coding agent, please read `/.github/COPILOT_CODING_AGENT.md` for repository-specific guidance including branching, PR body requirements, and quality gates.
+
+## Code style
+
+- ESLint (flat config) with React rules
+- Prettier for formatting (enforced in CI)
+
+## Tests
+
+- Vitest is configured. Please add a basic test for non-trivial logic.
+
+## Security
+
+- Never commit secrets.
+- If server credentials or API keys are required, document the environment variables in README and `.env.example`.

--- a/README.md
+++ b/README.md
@@ -18,19 +18,44 @@ A modern, luxe-themed React starter built with **Vite + TailwindCSS** featuring 
 ## 🚀 Quick Start
 
 ```bash
-##  License
+# Install dependencies
+npm install
 
-See [LICENSE](LICENSE) for details.
+# Start the development server
+npm run dev
 
+# Build for production
+npm run build
 
-# APIs
+# Preview the production build
+npm run preview
+```
+
+## 🔐 Environment variables
+
+Copy `.env.example` to `.env` and fill in the values you plan to use (optional for local demo):
+
+```env
+# Firebase
+FIREBASE_API_KEY=
+FIREBASE_AUTH_DOMAIN=
+FIREBASE_PROJECT_ID=
+FIREBASE_STORAGE_BUCKET=
+FIREBASE_MESSAGING_SENDER_ID=
+FIREBASE_APP_ID=
+
+# Stripe (optional)
+STRIPE_SECRET_KEY=
+STRIPE_PRICE_ID=
+
+# APIs (optional)
 REMOVEBG_API_KEY=
 EBAY_APP_ID=
 EBAY_CERT_ID=
 EBAY_DEV_ID=
 EBAY_OAUTH_TOKEN=
 
-# SendGrid (for weekly emails)
+# SendGrid (for weekly emails in Cloud Functions)
 SENDGRID_API_KEY=
 ```
 
@@ -127,6 +152,6 @@ For setup help or business collaboration:
 📧 **[support@photo2profit.app](mailto:support@photo2profit.app)**
 🌐 [photo2profit.app](https://photo2profit.app) _(coming soon)_
 
-```
-## 🔄 Automation Workflows
-```
+## 🤝 Contributing
+
+Please see `/.github/COPILOT_CODING_AGENT.md` for repository-specific onboarding and CI expectations. Pull requests should pass lint, format:check, tests, and build.


### PR DESCRIPTION
This PR cleans up README Quick Start, adds an Environment Variables section, introduces .env.example, and adds CONTRIBUTING.md.\n\nChanges\n- Fix malformed README code fences and Quick Start steps\n- Add Environment Variables section with example keys\n- Add .env.example for easy bootstrapping\n- Add CONTRIBUTING.md linking to onboarding and CI expectations\n\nWhy\n- Make onboarding and local usage clear, consistent, and CI-friendly\n\nHow to verify\n- README renders correctly\n- CI remains green (lint, format:check, tests, build)